### PR TITLE
Fixed a small issue in sbt launcher.

### DIFF
--- a/sbt
+++ b/sbt
@@ -1,1 +1,1 @@
-java -Xmx512m `dirname $0`/sbt-launch.jar "$@"
+java -Xmx512m -jar `dirname $0`/sbt-launch.jar "$@"


### PR DESCRIPTION
-jar was missing in sbt launcher script and it caused "Could not find the main class" error.
